### PR TITLE
Add arXiv target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ arXiv: realclean authors
 	cp -r src bib images submit_to_arXiv
 	mv submit_to_arXiv/HSF_ML_CWP.tex submit_to_arXiv/ms.tex
 	sed -i 's/HSF_ML_CWP/ms/g' submit_to_arXiv/Makefile
+	sed -i '/hyperref/,+7d' submit_to_arXiv/preamble.tex
 	tar -zcvf submit_to_arXiv.tar.gz submit_to_arXiv
 	rm -rf submit_to_arXiv
 	$(MAKE) realclean

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,10 @@ final:
 	make text
 	make clean
 
-arXiv: realclean authors
+arXiv: realclean document
 	mkdir submit_to_arXiv
 	cp *.tex submit_to_arXiv
+	cp *.bbl submit_to_arXiv/ms.bbl
 	cp Makefile submit_to_arXiv
 	cp -r src bib images submit_to_arXiv
 	mv submit_to_arXiv/HSF_ML_CWP.tex submit_to_arXiv/ms.tex

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,17 @@ final:
 	make figures
 	make text
 	make clean
+
+arXiv: realclean authors
+	mkdir submit_to_arXiv
+	cp *.tex submit_to_arXiv
+	cp Makefile submit_to_arXiv
+	cp -r src bib images submit_to_arXiv
+	mv submit_to_arXiv/HSF_ML_CWP.tex submit_to_arXiv/ms.tex
+	sed -i 's/HSF_ML_CWP/ms/g' submit_to_arXiv/Makefile
+	tar -zcvf submit_to_arXiv.tar.gz submit_to_arXiv
+	rm -rf submit_to_arXiv
+	$(MAKE) realclean
+
+clean_arXiv:
+	rm submit_to_arXiv.tar.gz

--- a/preamble.tex
+++ b/preamble.tex
@@ -13,11 +13,11 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage{hyperref}
 \hypersetup{
- colorlinks=true,       % false: boxed links; true: colored links
- linkcolor=black,          % color of internal links
- citecolor=green,        % color of links to bibliography
- filecolor=magenta,      % color of file links
- urlcolor=blue           % color of external links
+ colorlinks=true, % false: boxed links; true: colored links
+ linkcolor=black, % color of internal links
+ citecolor=blue, % color of links to bibliography
+ filecolor=magenta, % color of file links
+ urlcolor=blue % color of external links
 }
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
The arXiv target prepares a `tar.gz` file with all the necessary files for arXiv to build the document correctly.