### PR TITLE
Restrict deployment to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
               if [[ ! -z $CIRCLE_PULL_REQUEST ]]; then
                 SSHPASS=$LXPLUS_PASS sshpass -e scp HSF_ML_CWP.pdf feickert@lxplus.cern.ch:/eos/user/f/feickert/www/IML-CWP/PRs/draft_ml-cwp_PR${CIRCLE_PULL_REQUEST##*/}.pdf
                 echo "### File viewable at: https://cern.ch/feickert/IML-CWP/PRs/draft_ml-cwp_PR${CIRCLE_PULL_REQUEST##*/}.pdf"
-              else
+              elif [[ "$CIRCLE_BRANCH" == "master" ]]; then
                 SSHPASS=$LXPLUS_PASS sshpass -e scp HSF_ML_CWP.pdf feickert@lxplus.cern.ch:/eos/user/f/feickert/www/IML-CWP/draft_ml-cwp.pdf
                 echo "### File viewable at: https://cern.ch/feickert/IML-CWP/draft_ml-cwp.pdf"
               fi


### PR DESCRIPTION
The deployment to master should only occur during a PR merge or a push to master. This fixes an issue where a build would be triggered on another branch that would be turned into a PR but before the PR existed and so the control logic would still deploy to the master build location.