### PR TITLE
Add Python 2 installation stage to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install Python 2
+          command: sudo apt-get update -qq && sudo apt-get install -y -qq python-pip
+      - run:
           name: Print current datetime
           command: date -u '+%Y-%m-%d %H:%M:%S'
       - run:


### PR DESCRIPTION
Python had been removed as a dependency of the LaTeX Docker image. This simply restores it by installing Python 2 through apt-get in the CI stage, which adds a very small amount of time.